### PR TITLE
Extend process.env when spawning dotnet child process. Fixes #9 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "markdown-it": "^7.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
+    "object-extend": "^0.5.0",
     "path-to-regexp": "^1.5.3",
     "pixrem": "^3.0.1",
     "pleeease-filters": "^3.0.0",

--- a/run.js
+++ b/run.js
@@ -16,6 +16,7 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const webpack = require('webpack');
 const cp = require('child_process');
+const extend = require('object-extend');
 
 const tasks = new Map();
 
@@ -162,9 +163,9 @@ tasks.set('start', () => {
       const options = {
         cwd: path.resolve(__dirname, './server/'),
         stdio: ['ignore', 'pipe', 'inherit'],
-        env: {
+        env: extend(process.env, {
           ASPNETCORE_ENVIRONMENT: 'Development',
-        },
+        }),
       };
       cp.spawn('dotnet', ['watch', 'run'], options).stdout.on('data', data => {
         process.stdout.write(data);


### PR DESCRIPTION
I has the same Issue as in #9. This should fix the `Error: spawn dotnet ENOENT`