### PR TITLE
Fixes publish task pushing to configured remote repository

### DIFF
--- a/run.js
+++ b/run.js
@@ -142,7 +142,7 @@ tasks.set('publish', () => {
     .then(() => git('add', '.', '--all'))
     .then(() => git('commit', '--message', new Date().toUTCString())
       .catch(() => Promise.resolve()))
-    .then(() => git('push', 'origin', 'master', '--force', '--set-upstream'));
+    .then(() => git('push', remote.name, 'master', '--force', '--set-upstream'));
 });
 
 //


### PR DESCRIPTION
There is an error when running the 'publish' task because it tries to push to 'origin' remote instead of the previously configured remote.name (i.e. 'azure') remote repository.